### PR TITLE
Feat/recurse nested groups

### DIFF
--- a/ucs2mailman.py
+++ b/ucs2mailman.py
@@ -141,6 +141,7 @@ class ldapGroup:
             mailAddr = ldapParse(lines, "mailPrimaryAddress")
         if mailAddr and mailAddr[0] != "None":
             self.mailAddr = prefix+mailAddr[0]
+        self.nestedGroups = ldapParse(lines, "nestedGroup")
         users = ldapParse(lines, "users")
         if not users:
             users = ldapParse(lines, "uniqueMember")

--- a/ucs2mailman.py
+++ b/ucs2mailman.py
@@ -18,6 +18,7 @@ debug = False
 testMode = False
 testMode2 = False
 noDelete = False
+nested = True
 filterList = []
 excludeList = []
 replaceList = []
@@ -244,6 +245,10 @@ def collectGroups(lUsers, translate = None):
         if translate:
             g.mailAddr = replDomain(g.mailAddr, translate)
     return groups
+
+def recurseNestedGroups(lUsers, lGroups):
+    "Include users from nested groups"
+    pass
 
 # global MM context
 domManager = None
@@ -522,6 +527,7 @@ def usage(ret):
     print("Note that you will typically need to run this as root (with sudo).")
     print("Options: -d     => debug output")
     print(" -n             => don't do any changes to MailMan, just print actions")
+    print(" -R             => DON'T recurseively include nested group members")
     print(" -k             => keep subscribers, only add, don't delete (but print)")
     print(" -h             => output this help an exit")
     print(" -a adminMail   => use this user as owner/moderator for newly created lists (must exist!)")
@@ -537,13 +543,13 @@ def usage(ret):
 
 def main(argv):
     global debug, testMode, testMode2, noDelete, admin, prefix, userFile, groupFile
-    global filterList, excludeList, replaceList
+    global filterList, excludeList, replaceList, nested
     global userManager
     translate = None
     identity = "list"
     # TODO: Use getopt
     try:
-        (optlist, args) = getopt.gnu_getopt(argv[1:], 'hdnNka:t:f:x:p:u:g:s:r:')
+        (optlist, args) = getopt.gnu_getopt(argv[1:], 'hdnNRka:t:f:x:p:u:g:s:r:')
     except getopt.GetoptError as exc:
         print(exc)
         usage(1)
@@ -559,6 +565,9 @@ def main(argv):
             continue
         if opt == "-N":
             testMode2 = True
+            continue
+        if opt == "-R":
+            nested = False
             continue
         if opt == "-k":
             noDelete = True
@@ -593,6 +602,8 @@ def main(argv):
 
     lUsers = collectUsers()
     lGroups = collectGroups(lUsers, translate)
+    if nested:
+        recurseNestedGroups(lUsers, lGroups)
     # Debugging: Dump info
     for lg in lGroups:
         assert(lg.mailAddr is not None)

--- a/ucs2mailman.py
+++ b/ucs2mailman.py
@@ -260,7 +260,11 @@ def addtoGroup(lGroups, grp, ngrp, nest):
     # Special function: Subscribe groups to groups
     if nest < 0:
         if ngrp.mailAddr:
-            grp.userList.append(ngrp.mailAddr)
+            print(ngrp.mailAddr)
+            user = ldapUser(("uid=%s,dc=%s" % tuple(ngrp.mailAddr.split("@")),))
+            user.dName = "%s mailing list" % ngrp.mailAddr
+            user.primMail = ngrp.mailAddr
+            grp.userList.append(user)
         return
     # Add missing users
     for user in ngrp.userList:
@@ -487,6 +491,7 @@ def reconcile(lGroups, mLists):
                 ml.mlMembers.append(lUser.primMail)
                 if not testMode2:
                     mmUser = userManager.make_user(lUser.primMail, lUser.dName)
+                    assert(mmUser)
                     pref = list(mmUser.addresses)[0]
                     pref.verified_on = now()
                     mmUser.preferred_address = pref


### PR DESCRIPTION
This addresses issue #21.
We introduce the option -R N (default 1).
Positive numbers include nestedGroup members on mailing lists up to the recursion level N.
Zero switches off processing nestedGroup (as was always the case until recently)
Negative numbers instead does suubscribe the mailing list from a nestedGroup to the mailing list, just in case we need to go this direction in the future.
